### PR TITLE
Base64file.upload: want_obj option

### DIFF
--- a/elu.js
+++ b/elu.js
@@ -1434,7 +1434,7 @@ var Base64file = {
 
                         clearInterval (timer)
 
-                        if (o.onloadend) o.onloadend (id)
+                        if (o.onloadend) o.onloadend (o.want_obj ? data : id)
 
                     }
 


### PR DESCRIPTION
Новая опция, при указании которой, результатом работы Promise будет не id файла, а объект data, который возвращает функция загрузки файла на бэкенде.
Удобно использовать, когда в ответ на загрузку файла нужно сформирвать отчёт - сгенерировать xlsx или docx на фронтенде из json ответа бэкенда.